### PR TITLE
fix(twa): never skip client warmup

### DIFF
--- a/app/src/main/java/si/maev/twa/TwaLauncher.java
+++ b/app/src/main/java/si/maev/twa/TwaLauncher.java
@@ -36,7 +36,7 @@ import androidx.browser.trusted.TokenStore;
 import androidx.browser.trusted.TrustedWebActivityIntent;
 import androidx.browser.trusted.TrustedWebActivityIntentBuilder;
 
-import com.google.androidbrowserhelper.trusted.ChromeLegacyUtils;
+//import com.google.androidbrowserhelper.trusted.ChromeLegacyUtils;
 import com.google.androidbrowserhelper.trusted.ChromeOsSupport;
 import com.google.androidbrowserhelper.trusted.FocusActivity;
 import com.google.androidbrowserhelper.trusted.LauncherActivityMetadata;
@@ -381,10 +381,12 @@ public class TwaLauncher {
         @Override
         public void onCustomTabsServiceConnected(@NonNull ComponentName componentName,
                                                  @NonNull CustomTabsClient client) {
-            if (!ChromeLegacyUtils
-                    .supportsLaunchWithoutWarmup(mContext.getPackageManager(), mProviderPackage)) {
-                client.warmup(0);
-            }
+//            // Skipping warmup breaks relationship validation.
+//            // This broken validation prevents custom headers from being sent while the ui still looks valid (no url bar shown).
+//            if (!ChromeLegacyUtils
+//                    .supportsLaunchWithoutWarmup(mContext.getPackageManager(), mProviderPackage)) {
+            client.warmup(0);
+//            }
 
             try {
                 mSession = client.newSession(mCustomTabsCallback, mSessionId);


### PR DESCRIPTION
Appears to fix the bug where no custom headers are sent on many devices.